### PR TITLE
update body font-size to use calc for min size

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 body {
   height: 200em;
   background-color: #5cdb95;
-  font-size: 1.1vw;
+  font-size: calc(8px + 0.5vw);
   margin: 0;
 }
 


### PR DESCRIPTION
Just a rough example of what I mentioned after your presentation.

Using [calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc), I've made sure the font size never goes below 8px, but is still "responsive" to viewport width. This way, font is still a decent size on the narrower screen.